### PR TITLE
Add developers and contributors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,23 +23,41 @@
 
 	<developers>
 		<developer>
-			<id>tom</id>
-			<name>Tom Maddock</name>
-			<roles>
-				<role>architect</role>
-				<role>developer</role>
-			</roles>
-		</developer>
-		<developer>
 			<id>tferr</id>
 			<name>Tiago Ferreira</name>
 			<email>tiagoalvespedrosa@gmail.com</email>
 			<organization>McGill</organization>
 			<roles>
+				<role>lead</role>
 				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
 			</roles>
 		</developer>
 	</developers>
+	<contributors>
+		<contributor>
+			<name>Tom Maddock</name>
+			<roles><role>founder</role></roles>
+		</contributor>
+		<contributor>
+			<name>Mark Hiner</name>
+			<url>http://imagej.net/User:Hinerm</url>
+			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>http://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Johannes Schindelin</name>
+			<url>http://imagej.net/User:Schindelin</url>
+			<properties><id>dscho</id></properties>
+		</contributor>
+	</contributors>
 
 	<scm>
 		<connection>scm:git:git://github.com/tferr/ASA</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 	<name>Sholl Analysis</name>
 	<description>An ImageJ 1.x plugin that uses automated Sholl to perform neuronal morphometry directly from bitmap images</description>
 	<url>http://fiji.sc/Sholl</url>
+	<inceptionYear>2005</inceptionYear>
 
 	<developers>
 		<developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>13.0.1</version>
+		<version>18.1.0</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,5 +66,4 @@
 			<artifactId>fiji-lib</artifactId>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,14 @@
 		<tag>HEAD</tag>
 		<url>https://github.com/tferr/ASA</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/tferr/ASA/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/Sholl-Analysis/</url>
+	</ciManagement>
 
 	<repositories>
 		<!-- NB: for project parent -->
@@ -66,4 +74,5 @@
 			<artifactId>fiji-lib</artifactId>
 		</dependency>
 	</dependencies>
+
 </project>


### PR DESCRIPTION
These patches clean up the POMs in a couple of ways.

In particular, they add the developers and contributors sections which we are now using to autogenerate wiki pages documenting [team roles](http://imagej.net/Team) for each project.