### PR TITLE
Use imagej.net URL for all developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
 		<developer>
 			<id>tferr</id>
 			<name>Tiago Ferreira</name>
-			<email>tiagoalvespedrosa@gmail.com</email>
-			<organization>McGill</organization>
+			<url>http://imagej.net/User:Tiago</url>
 			<roles>
 				<role>lead</role>
 				<role>developer</role>


### PR DESCRIPTION
And remove the other info, which is prone to obsolescence.

This information is available from the imagej.net user profile, in an indirect way which can be updated in case it changes, rather than being baked into the POM forever.

This change will make automatic generation of informational sidebars on the wiki easier to accomplish.