### PR TITLE
Update to pom-scijava parent, and switch to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only: master
+install: true
+script: ".travis/build.sh"
+after_success: ".travis/notify.sh Travis-Success"
+after_failure: ".travis/notify.sh Travis-Failure"
+env:
+  global:
+  - secure: GZ4KzecvJukeXrfLW/qZPm18mnB0W33uP8dRE+qbmzT2PDgLU+cE6iRPPA6raaHkB7DhOItnoVLK7fsmABa+WfspSkQmMl03ZCkwl975Xn2+7skmpC58yLKRURyOvBP0RkIM/SUkP6xcKT8MF21yVq8bTEbYx+OnVxCMHpjq8GU=
+  - secure: kB+KUaZnCyUc1wxhhdPndnvJSUPcSGsUXS9TzEq7evMK7AXYS7KDmNdVYcct5ugJuGAMWi5OZNu7L3Mw/ifk4pQ5j/QEoZU4YMNzv6UwWcLMrpc1ki7syYnrdkR+G04zk/5Dr9JVC/lFPSyu8pazJDzdBHj5S/USWbbLfExKY6g=

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+dir="$(dirname "$0")"
+test "$TRAVIS_SECURE_ENV_VARS" = true \
+  -a "$TRAVIS_PULL_REQUEST" = false \
+  -a "$TRAVIS_BRANCH" = master &&
+  mvn -Pdeploy-to-imagej deploy --settings "$dir/settings.xml" ||
+  mvn install

--- a/.travis/notify.sh
+++ b/.travis/notify.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+curl -fs "https://jenkins.imagej.net/job/$1/buildWithParameters?token=$TOKEN_NAME&repo=$TRAVIS_REPO_SLUG&commit=$TRAVIS_COMMIT&pr=$TRAVIS_PULL_REQUEST"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>imagej.releases</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+    <server>
+      <id>imagej.snapshots</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+  </servers>
+</settings>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Sholl Analysis](http://imagej.net/Sholl)
 [![DOI](https://zenodo.org/badge/4622/tferr/ASA.svg)](https://zenodo.org/badge/latestdoi/4622/tferr/ASA)
-[![Jenkins](http://img.shields.io/jenkins/s/http/jenkins.imagej.net/Sholl-Analysis.svg?style=flat-square)](http://jenkins.imagej.net/job/Sholl-Analysis/)
+[![Travis](https://travis-ci.org/tferr/ASA.svg?branch-master)](https://travis-ci.org/tferr/ASA)
 [![Latest Release](https://img.shields.io/github/release/tferr/ASA.svg?style=flat-square)](https://github.com/tferr/ASA/releases)
 [![Issues](https://img.shields.io/github/issues/tferr/ASA.svg?style=flat-square)](https://github.com/tferr/ASA/issues)
 [![GPL License](http://img.shields.io/badge/license-GPL-blue.svg?style=flat-square)](http://opensource.org/licenses/GPL-3.0)
@@ -48,7 +48,7 @@ that presents the software in greater detail.
 ##Installation
 If you use Fiji, you already have _Sholl Analysis_ installed and can start [using it](http://imagej.net/Sholl_Analysis#Usage)
 right away. Binaries are available from the [documentation page](http://imagej.net/Sholl_Analysis)
-or from [jenkins.imagej.net](http://jenkins.imagej.net/job/Sholl-Analysis/lastStableBuild/).
+or from the [ImageJ Maven repository](http://maven.imagej.net/#nexus-search;gav~ca.mcgill~Sholl_Analysis~~~).
 
 
 ## Help?

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 		<url>https://github.com/tferr/ASA/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/Sholl-Analysis/</url>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/tferr/ASA</url>
 	</ciManagement>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
 	</ciManagement>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>26.1.1</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>14.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -20,6 +20,17 @@
 	<description>An ImageJ 1.x plugin that uses automated Sholl to perform neuronal morphometry directly from segmented images and traces from Simple Neurite Tracer</description>
 	<url>http://imagej.net/Sholl</url>
 	<inceptionYear>2005</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v3+</name>
+			<url>https://www.gnu.org/licenses/gpl.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<developers>
 		<developer>
@@ -58,6 +69,13 @@
 		</contributor>
 	</contributors>
 
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
 	<scm>
 		<connection>scm:git:git://github.com/tferr/ASA</connection>
 		<developerConnection>scm:git:git@github.com:tferr/ASA</developerConnection>
@@ -72,6 +90,13 @@
 		<system>Jenkins</system>
 		<url>http://jenkins.imagej.net/job/Sholl-Analysis/</url>
 	</ciManagement>
+
+	<properties>
+		<package-name>sholl</package-name>
+		<license.licenseName>gpl_v3</license.licenseName>
+		<license.copyrightOwners>Tiago Ferreira.</license.copyrightOwners>
+		<license.projectName>Sholl Analysis plugin for ImageJ.</license.projectName>
+	</properties>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
Note that to fully switch to Travis, you will need to visit https://travis-ci.org/tferr/ASA and enable the repository there.