### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>https://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/sholl-analysis</archive>
 		</mailingList>
 	</mailingLists>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>25.0.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -94,14 +94,14 @@
 		<license.copyrightOwners>Tiago Ferreira.</license.copyrightOwners>
 		<license.projectName>Sholl Analysis plugin for ImageJ.</license.projectName>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>https://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.