### PR TITLE
Reduce dependency footprint and cleanup the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,15 +106,33 @@
 	</repositories>
 
 	<dependencies>
+		<!-- Fiji dependencies -->
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>fiji-lib</artifactId>
+		</dependency>
+
 		<!-- ImageJ dependencies -->
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>sc.fiji</groupId>
-			<artifactId>fiji-lib</artifactId>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-common</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+		</dependency>
+
+		<!-- ImgLib2 dependencies -->
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+
+		<!-- SciJava dependencies -->
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
@@ -123,21 +141,11 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-table</artifactId>
 		</dependency>
+
+		<!-- Other dependencies -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-legacy</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imglib2</groupId>
-			<artifactId>imglib2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-common</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -131,5 +131,13 @@
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-legacy</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-common</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,6 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>ij1-patcher</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
 			<artifactId>imagej-legacy</artifactId>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,6 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>imagej</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
 			<artifactId>ij1-patcher</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/sholl/Options.java
+++ b/src/main/java/sholl/Options.java
@@ -31,7 +31,6 @@ import java.util.Map.Entry;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 
-import fiji.Debug;
 import ij.IJ;
 import ij.Prefs;
 import ij.measure.Measurements;
@@ -151,16 +150,6 @@ public class Options implements PlugIn {
 
 	public Options() {
 		this(false);
-	}
-
-	/**
-	 * Debug helper
-	 *
-	 * @param args
-	 *            See {@link fiji.Debug#run(java.lang.String, java.lang.String)}
-	 */
-	public static void main(final String[] args) {
-		Debug.run(COMMAND_LABEL, "");
 	}
 
 	/**

--- a/src/main/java/sholl/gui/ShollTable.java
+++ b/src/main/java/sholl/gui/ShollTable.java
@@ -323,15 +323,4 @@ public class ShollTable extends DefaultGenericTable {
 			setDetailedSummary(detailedMetrics);
 		}
 	}
-
-	/**
-	 * The main method.
-	 *
-	 * @param args the arguments
-	 */
-	public static void main(final String[] args) {
-		// TODO Auto-generated method stub
-
-	}
-
 }

--- a/src/main/java/sholl/parsers/ImageParser2D.java
+++ b/src/main/java/sholl/parsers/ImageParser2D.java
@@ -66,14 +66,6 @@ public class ImageParser2D extends ImageParser {
 		doSpikeSupression = true;
 	}
 
-	/* Debug method **/
-	public static void main(final String... args) throws Exception {
-		// final ImageJ ij = net.imagej.Main.launch(args);
-		// final ImageParser2D parser = new
-		// ImageParser2D(Sholl_Utils.sampleImage());
-		// parser.parse();
-	}
-
 	public void setCenterPx(final int x, final int y) {
 		super.setCenterPx(x, y, 1);
 	}

--- a/src/main/java/sholl/plugin/ChooseDataset.java
+++ b/src/main/java/sholl/plugin/ChooseDataset.java
@@ -81,6 +81,7 @@ public class ChooseDataset extends DynamicCommand {
 		final List<Dataset> list = datasetService.getDatasets();
 		if (list == null || list.size() < 2) {
 			cancel("No other images are open.");
+			return;
 		}
 		for (final Dataset dataset : list) {
 			if (dataset.equals(datasetToIgnore))

--- a/src/main/java/sholl/plugin/ChooseDataset.java
+++ b/src/main/java/sholl/plugin/ChooseDataset.java
@@ -42,7 +42,7 @@ import org.scijava.prefs.PrefService;
  * @author Tiago Ferreira
  */
 @Plugin(initializer = "init", type = Command.class, visible = false, label = "Choose New Dataset")
-public class ChooseDataset extends DynamicCommand implements Command {
+public class ChooseDataset extends DynamicCommand {
 
 	@Parameter
 	private DatasetService datasetService;

--- a/src/main/java/sholl/plugin/ChooseDataset.java
+++ b/src/main/java/sholl/plugin/ChooseDataset.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
-import net.imagej.ImageJ;
 
 import org.scijava.ItemVisibility;
 import org.scijava.command.Command;
@@ -93,12 +92,6 @@ public class ChooseDataset extends DynamicCommand {
 			String.class);
 		mItem.setChoices(choices);
 		// mItem.setValue(this, choices.get(0));
-	}
-
-	public static void main(final String... args) {
-		final ImageJ ij = new ImageJ();
-		ij.ui().showUI();
-		ij.command().run(ChooseDataset.class, true);
 	}
 
 }

--- a/src/main/java/sholl/plugin/Prefs.java
+++ b/src/main/java/sholl/plugin/Prefs.java
@@ -52,7 +52,7 @@ import sholl.gui.Helper;
  */
 @Plugin(type = Command.class, label = "Sholl Options", visible = false,
 	initializer = "init")
-public class Prefs extends OptionsPlugin implements Command {
+public class Prefs extends OptionsPlugin {
 
 	@Parameter
 	private AppService appService;

--- a/src/main/java/sholl/plugin/Prefs.java
+++ b/src/main/java/sholl/plugin/Prefs.java
@@ -24,10 +24,6 @@ package sholl.plugin;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
-import net.imagej.ImageJ;
 
 import org.scijava.ItemVisibility;
 import org.scijava.app.AppService;
@@ -56,8 +52,6 @@ public class Prefs extends OptionsPlugin {
 
 	@Parameter
 	private AppService appService;
-	@Parameter
-	private ImageJ ij;
 	@Parameter
 	private PrefService pService;
 	@Parameter
@@ -205,7 +199,7 @@ public class Prefs extends OptionsPlugin {
 		final StringBuilder sb = new StringBuilder();
 		sb.append("You are running Sholl Analysis v").append(ShollUtils.version());
 		sb.append(" ").append(ShollUtils.buildDate()).append("\n");
-		sb.append("on ImageJ ").append(ij.getVersion());
+		sb.append("on ImageJ ").append(appService.getApp().getVersion());
 		helper.infoMsg(sb.toString(), null);
 	}
 
@@ -250,14 +244,6 @@ public class Prefs extends OptionsPlugin {
 		helper.infoMsg("Preferences were successfully reset.", null);
 		restartRequired = true;
 
-	}
-
-	public static void main(final String... args) {
-		final ImageJ ij = new ImageJ();
-		ij.ui().showUI();
-		final Map<String, Object> inputs = new HashMap<>();
-		inputs.put("ignoreBitmapOptions", true);
-		ij.command().run(Prefs.class, true, inputs);
 	}
 
 }

--- a/src/main/java/sholl/plugin/ShollAnalysisImg.java
+++ b/src/main/java/sholl/plugin/ShollAnalysisImg.java
@@ -66,7 +66,6 @@ import ij.gui.Roi;
 import ij.measure.Calibration;
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
-import net.imagej.ImageJ;
 import net.imagej.display.ImageDisplayService;
 import net.imagej.event.DataDeletedEvent;
 import net.imagej.legacy.LegacyService;
@@ -1048,11 +1047,5 @@ public class ShollAnalysisImg extends DynamicCommand implements Interactive {
 				return; // invalid parameters: do nothing
 			}
 		}
-	}
-
-	public static void main(final String... args) {
-		final ImageJ ij = new ImageJ();
-		ij.ui().showUI();
-		ij.command().run(ShollAnalysisImg.class, true);
 	}
 }

--- a/src/main/java/sholl/plugin/ShollAnalysisImg.java
+++ b/src/main/java/sholl/plugin/ShollAnalysisImg.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.scijava.Cancelable;
 import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
@@ -96,7 +95,7 @@ import sholl.parsers.ImageParser3D;
  */
 @Plugin(type = Command.class, menu = { @Menu(label = "Analyze"), @Menu(label = "Sholl", weight = 0.01d),
 		@Menu(label = "Sholl Analysis (From Image)...") }, initializer = "init")
-public class ShollAnalysisImg extends DynamicCommand implements Interactive, Cancelable {
+public class ShollAnalysisImg extends DynamicCommand implements Interactive {
 
 	@Parameter
 	private CommandService cmdService;


### PR DESCRIPTION
These patches eliminate the dependency on net.imagej:imagej, reducing the dependency footprint from 151 dependencies down to 42. It also fixes some minor issues.